### PR TITLE
Use env_logger instead of custom RUST_LOG_IGNORE env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,9 @@
 [[package]]
 name = "aho-corasick"
-version = "0.6.4"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -52,8 +52,20 @@ dependencies = [
  "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -84,15 +96,17 @@ name = "log"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -138,19 +152,19 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -176,6 +190,7 @@ name = "stackdriver_logger"
 version = "0.3.0"
 dependencies = [
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -190,6 +205,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,11 +224,10 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -224,21 +246,13 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "utf8-ranges"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "void"
-version = "1.0.2"
+name = "version_check"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -256,6 +270,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,39 +290,51 @@ dependencies = [
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "wincolor"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
-"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
+"checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
-"checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0e6e40ebb0e66918a37b38c7acab4e10d299e0463fe2af5d29b9cc86710cfd2a"
+"checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
-"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9"
 "checksum num-integer 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "6ac0ea58d64a89d9d6b7688031b3be9358d6c919badcf7fbb0527ccfd891ee45"
 "checksum num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28"
 "checksum pretty_env_logger 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "26d3bc10ef768a4e8eae257706926f17c76b48b6efc65335cfce12527e7348d6"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
-"checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
+"checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
+"checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
 "checksum serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)" = "fba5be06346c5200249c8c8ca4ccba4a09e8747c71c16e420bd359a0db4d8f91"
 "checksum serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "93aee34bb692dde91e602871bc792dd319e489c7308cdbbe5f27cf27c64280f5"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
+"checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
-"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
-"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
-"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"
+"checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,11 @@ categories = ["development-tools::debugging"]
 keywords = ["log", "logging", "cloud", "google", "stackdriver"]
 readme = "README.md"
 repository = "https://github.com/kamek-pf/stackdriver-logger/"
+edition = "2018"
 
 [dependencies]
-log = "0.4.1"
-serde_json = "1.0.19"
-chrono = "0.4.2"
-pretty_env_logger = "0.2.3"
+chrono = "0.4"
+env_logger = "0.6"
+log = "0.4"
+pretty_env_logger = "0.2"
+serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,76 +1,14 @@
 // #![doc(include = "../README.md")]
 
-extern crate chrono;
-extern crate log;
-extern crate pretty_env_logger;
-
 #[macro_use]
 extern crate serde_json;
 
+use chrono::Utc;
+use env_logger::Builder;
+use log::{Level, Record, SetLoggerError};
+use serde_json::Value;
 use std::env;
 use std::fmt;
-
-use chrono::Utc;
-use log::{Level, Log, Metadata, Record, SetLoggerError, STATIC_MAX_LEVEL};
-use serde_json::Value;
-
-struct StackdriverLogger {
-    service_name: String,
-    service_version: String,
-    ignored_paths: Vec<String>,
-}
-
-impl StackdriverLogger {
-    fn format_record(&self, record: &Record) -> Value {
-        let message = match record.level() {
-            Level::Error => format!(
-                "{} \n at {}:{}",
-                record.args(),
-                record.file().unwrap_or("unknown_file"),
-                record.line().unwrap_or(0)
-            ),
-            _ => format!("{}", record.args()),
-        };
-
-        json!({
-            "eventTime": Utc::now().to_rfc3339(),
-            "serviceContext": {
-                "service": self.service_name,
-                "version": self.service_version
-            },
-            "message": message,
-            "severity": map_level(&record.level()).to_string(),
-            "reportLocation": {
-                "filePath": record.file(),
-                "modulePath": record.module_path(),
-                "lineNumber": record.line(),
-            }
-        })
-    }
-}
-
-impl Log for StackdriverLogger {
-    fn enabled(&self, metadata: &Metadata) -> bool {
-        let has_level = metadata.level() <= STATIC_MAX_LEVEL;
-        let is_allowed = !self.ignored_paths.iter().any(|e| e == metadata.target());
-
-        has_level && is_allowed
-    }
-
-    fn log(&self, record: &Record) {
-        if self.enabled(record.metadata()) {
-            let formatted = self.format_record(record);
-
-            if record.level() == Level::Error {
-                eprintln!("{}", formatted);
-            } else {
-                println!("{}", formatted);
-            }
-        }
-    }
-
-    fn flush(&self) {}
-}
 
 /// Log levels available in Stackdriver
 #[derive(Debug)]
@@ -86,7 +24,7 @@ pub enum StackdriverLogLevel {
 }
 
 impl fmt::Display for StackdriverLogLevel {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             StackdriverLogLevel::Debug => write!(f, "DEBUG"),
             StackdriverLogLevel::Info => write!(f, "INFO"),
@@ -100,48 +38,54 @@ impl fmt::Display for StackdriverLogLevel {
     }
 }
 
-fn try_init() -> Result<(), SetLoggerError> {
+fn try_init(service: Option<Service>, report_location: bool) -> Result<(), SetLoggerError> {
     if cfg!(debug_assertions) {
-        pretty_env_logger::init();
-        Ok(())
+        pretty_env_logger::try_init()
     } else {
-        let service_name = env::var("SERVICE_NAME")
-            .or(env::var("CARGO_PKG_NAME"))
-            .unwrap_or("".to_owned());
+        let mut builder = formatted_builder(service, report_location);
 
-        let service_version = env::var("SERVICE_VERSION")
-            .or(env::var("CARGO_PKG_VERSION"))
-            .unwrap_or("".to_owned());
+        if let Ok(s) = ::std::env::var("RUST_LOG") {
+            builder.parse(&s);
+        }
 
-        let logger = StackdriverLogger {
-            service_name,
-            service_version,
-            ignored_paths: get_ignored_paths(env::var("RUST_LOG_IGNORE").ok()),
-        };
-
-        log::set_max_level(STATIC_MAX_LEVEL);
-        log::set_boxed_logger(Box::new(logger))
-    }
-}
-
-fn get_ignored_paths(paths: Option<String>) -> Vec<String> {
-    match paths {
-        None => vec![],
-        Some(value) => value
-            .split(',')
-            .filter_map(|value| match value {
-                "" => None,
-                other => Some(other.to_owned()),
-            })
-            .collect(),
+        builder.try_init()
     }
 }
 
 /// Initialize the logger.
 /// For debug build, this falls back to pretty_env_logger.
-/// For release build, we're using the json structure expected by Stackdriver.
+/// For release build, we're using the json structure expected by Stackdriver (without service and
+/// with report location).
 pub fn init() {
-    try_init().expect("Could not initialize stackdriver_logger");
+    try_init(None, true).expect("Could not initialize stackdriver_logger");
+}
+
+/// Initialize the logger.
+/// For debug build, this falls back to pretty_env_logger.
+/// For release build, we're using the json structure expected by Stackdriver.
+pub fn init_with(service: Option<Service>, report_location: bool) {
+    try_init(service, report_location).expect("Could not initialize stackdriver_logger");
+}
+
+/// Returns a `env_logger::Builder` for further customization.
+///
+/// This method will return a stackdriver JSON formatted `env_logger::Builder`
+/// for further customization. Refer to env_logger::Build crate documentation
+/// for further details and usage.
+pub fn formatted_builder(service: Option<Service>, report_location: bool) -> Builder {
+    use std::io::Write;
+
+    let mut builder = Builder::new();
+
+    builder.format(move |f, record| {
+        writeln!(
+            f,
+            "{}",
+            format_record(record, service.as_ref(), report_location)
+        )
+    });
+
+    builder
 }
 
 fn map_level(input: &Level) -> StackdriverLogLevel {
@@ -153,41 +97,64 @@ fn map_level(input: &Level) -> StackdriverLogLevel {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[derive(Clone)]
+pub struct Service {
+    name: String,
+    version: String,
+}
 
-    #[test]
-    fn parse_ignored_() {
-        let input = None;
-        let paths = get_ignored_paths(input);
-        let expected: Vec<String> = vec![];
-        assert_eq!(paths, expected);
+impl Service {
+    pub fn from_env() -> Option<Service> {
+        let name = env::var("SERVICE_NAME")
+            .or(env::var("CARGO_PKG_NAME"))
+            .unwrap_or("".to_owned());
 
-        let input = Some("module".to_owned());
-        let paths = get_ignored_paths(input);
-        assert_eq!(paths, vec!["module"]);
+        let version = env::var("SERVICE_VERSION")
+            .or(env::var("CARGO_PKG_VERSION"))
+            .unwrap_or("".to_owned());
 
-        let input = Some("some::module".to_owned());
-        let paths = get_ignored_paths(input);
-        assert_eq!(paths, vec!["some::module"]);
+        if name.is_empty() && version.is_empty() {
+            return None;
+        }
 
-        let input = Some("some::module,and_another".to_owned());
-        let paths = get_ignored_paths(input);
-        assert_eq!(paths, vec!["some::module", "and_another"]);
+        Some(Service { name, version })
+    }
+}
 
-        let input = Some("some::module,and_another,plus::something_else,".to_owned());
-        let paths = get_ignored_paths(input);
-        assert_eq!(
-            paths,
-            vec!["some::module", "and_another", "plus::something_else"]
-        );
+fn format_record(record: &Record<'_>, service: Option<&Service>, report_location: bool) -> Value {
+    let message = match record.level() {
+        Level::Error => format!(
+            "{} \n at {}:{}",
+            record.args(),
+            record.file().unwrap_or("unknown_file"),
+            record.line().unwrap_or(0)
+        ),
+        _ => format!("{}", record.args()),
+    };
 
-        let input = Some("some::module,and_another,with::trailing::comma,".to_owned());
-        let paths = get_ignored_paths(input);
-        assert_eq!(
-            paths,
-            vec!["some::module", "and_another", "with::trailing::comma"]
+    let mut value = json!({
+        "eventTime": Utc::now().to_rfc3339(),
+        "message": message,
+        "severity": map_level(&record.level()).to_string(),
+    });
+    if let Some(service) = service {
+        value.as_object_mut().unwrap().insert(
+            "serviceContext".to_string(),
+            json!({
+                "service": service.name,
+                "version": service.version
+            }),
         );
     }
+    if report_location {
+        value.as_object_mut().unwrap().insert(
+            "reportLocation".to_string(),
+            json!({
+                "filePath": record.file(),
+                "modulePath": record.module_path(),
+                "lineNumber": record.line(),
+            }),
+        );
+    }
+    value
 }


### PR DESCRIPTION
This PR makes the logger use the `env_logger` environment variable convention and filtering implementation.