### PR TITLE
Add customfields feature for structured logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ atty = ["env_logger/atty"]
 humantime = ["env_logger/humantime"]
 regex = ["env_logger/regex"]
 
+# Toggle log features
+customfields = ["log/kv_unstable"]
+
 [dependencies]
 env_logger = { version = "0.7.1", default-features = false }
 pretty_env_logger = { version = "0.4.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ pub(crate) fn try_init(
     }
 
     #[cfg(not(all(feature = "pretty_env_logger", debug_assertions)))]
-    {
+    { 
         use std::io::Write;
         let mut builder = env_logger::Builder::new();
         builder.format(move |f, record| {
@@ -223,7 +223,7 @@ fn format_record(
     {
         let mut json_payload = json_payload;
         let mut custom_fields = CustomFields::new();
-        if let Ok(_) = record.key_values().visit(&mut custom_fields) {
+        if record.key_values().visit(&mut custom_fields).is_ok() {
             for (key, val) in custom_fields.inner().iter() {
                 json_payload[key.as_str()] = Value::String(val.to_string());
             }
@@ -239,13 +239,13 @@ fn format_record_pretty(
     let mut message = format!("{}", record.args());
     let mut custom_fields = CustomFields::new();
     let mut kv_message_parts = vec![];
-    if let Ok(_) = record.key_values().visit(&mut custom_fields) {
+    if record.key_values().visit(&mut custom_fields).is_ok() {
         for (key, val) in custom_fields.inner().iter() {
             kv_message_parts.push(format!("{}={}", key, val));
         }
     }
 
-    if kv_message_parts.len() > 0 {
+    if !kv_message_parts.is_empty() {
         kv_message_parts.sort();
         message = format!("{} {}", message, kv_message_parts.join(", "))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,20 +119,14 @@ pub(crate) fn try_init(
         {
             use std::io::Write;
             let mut builder = env_logger::Builder::new();
-            builder.format(move |f, record| {
-                writeln!(
-                    f,
-                    "{}",
-                    format_record_pretty(record)
-                )
-            });
+            builder.format(move |f, record| writeln!(f, "{}", format_record_pretty(record)));
         }
 
         pretty_env_logger::try_init()
     }
 
     #[cfg(not(all(feature = "pretty_env_logger", debug_assertions)))]
-    { 
+    {
         use std::io::Write;
         let mut builder = env_logger::Builder::new();
         builder.format(move |f, record| {
@@ -232,10 +226,12 @@ fn format_record(
     }
 }
 
-#[cfg(all(feature = "pretty_env_logger", feature = "customfields", debug_assertions))]
-fn format_record_pretty(
-    record: &log::Record<'_>
-) -> String {    
+#[cfg(all(
+    feature = "pretty_env_logger",
+    feature = "customfields",
+    debug_assertions
+))]
+fn format_record_pretty(record: &log::Record<'_>) -> String {
     let mut message = format!("{}", record.args());
     let mut custom_fields = CustomFields::new();
     let mut kv_message_parts = vec![];

--- a/test_snapshots/custom_fields.json
+++ b/test_snapshots/custom_fields.json
@@ -1,6 +1,6 @@
 {
     "eventTime": "2019-09-28T04:00:00.000000000+00:00",
-    "message": "",
+    "message": "Info!",
     "reportLocation": null,
     "serviceContext": {
         "service": "test",

--- a/test_snapshots/custom_fields.json
+++ b/test_snapshots/custom_fields.json
@@ -1,0 +1,12 @@
+{
+    "eventTime": "2019-09-28T04:00:00.000000000+00:00",
+    "message": "",
+    "reportLocation": null,
+    "serviceContext": {
+        "service": "test",
+        "version": "0.0.0"
+    },
+    "severity": "INFO",
+    "a": "a value",
+    "b": "b value"
+}


### PR DESCRIPTION
This PR proposes adding the ability to include structured data in the stackdriver log and is behind a `customfields` feature flag. It's turned off by default and in all cases as [the underlying log feature](https://github.com/rust-lang/log/issues/328) it depends on is still unstable.