### PR TITLE
Minor changes: formatting, dependencies, documentation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,14 @@ repository = "https://github.com/kamek-pf/stackdriver-logger/"
 edition = "2018"
 
 [features]
-default = ["cargo", "termcolor", "atty", "humantime", "regex", "pretty_env_logger"]
+default = [
+    "cargo",
+    "termcolor",
+    "atty",
+    "humantime",
+    "regex",
+    "pretty_env_logger",
+]
 prod = ["cargo"]
 
 # Used by the init macro

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackdriver_logger"
-version = "0.7.0"
+version = "0.8.1"
 description = "A logger for Google's Stackdriver with a cli-friendly fallback for local development"
 authors = ["Kamek <b.kamek@gmail.com>"]
 license = "MIT/Apache-2.0"
@@ -8,7 +8,7 @@ categories = ["development-tools::debugging"]
 keywords = ["log", "logging", "cloud", "google", "stackdriver"]
 readme = "README.md"
 repository = "https://github.com/kamek-pf/stackdriver-logger/"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = [
@@ -34,9 +34,9 @@ regex = ["env_logger/regex"]
 customfields = ["log/kv_unstable"]
 
 [dependencies]
-env_logger = { version = "0.7.1", default-features = false }
+env_logger = { version = "0.9.3", default-features = false }
 pretty_env_logger = { version = "0.4.0", optional = true }
-chrono = "0.4.10"
-serde_json = "1.0.47"
-log = "0.4.8"
-toml = { version = "0.5.6", optional = true }
+chrono = "0.4.23"
+serde_json = "1.0.87"
+log = "0.4.17"
+toml = { version = "0.5.9", optional = true }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ By default, in debug mode, we fall back back to [`pretty_env_logger`](https://gi
 In release mode, we output JSON formatted logs compatible with Stackdriver.
 
 ## Usage
+
 ```rust
 use stackdriver_logger;
 use log::{error, info, trace, debug, warn};
@@ -19,10 +20,12 @@ fn main() {
     error!("error log");
 }
 ```
+
 Note that the `init_with_cargo!` macro will include your `Cargo.toml` in the resulting binary.
 If you don't want that, check out the docs, a few more initializers are available.
 
 ## Behavior
+
 When using the above macro, you don't have anything else to do.
 For other initializers, you may need to provide two environment variables : `SERVICE_NAME` and `SERVICE_VERSION`.
 We're using Cargo's `CARGO_PKG_NAME` and `CARGO_PKG_VERSION` as a fallback, but these are only available
@@ -30,6 +33,7 @@ if you run your application via Cargo. \
 Check out the docs to see which initializers require environment variables.
 
 ## Enabling logging
+
 This library accepts a `RUST_LOG` env variable, it works exactly like in [`env_logger`](https://github.com/sebasmagri/env_logger). \
 By default, everything is disabled except for `error!`.
 To enable all logs for your application :
@@ -41,16 +45,18 @@ RUST_LOG=your_application cargo run
 For more details, take a look at the [`env_logger` docs](https://docs.rs/env_logger/0.7.0/env_logger/#enabling-logging).
 
 ## Feature flags
+
 By default, this crate enables all `env_logger` defaults features and always pulls `pretty_env_logger`. \
 These crates have some heavy dependencies like `regex`. \
 If you want smaller builds in production, and don't use fancy `env_logger` features, you can disable default features for `stackdriver_logger` like so :
+
 ```
 stackdriver_logger = { version = "*", default-features = false, features = ["prod"] }
 ```
 
 ## License
+
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
-
+-   Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://apache.org/licenses/LICENSE-2.0)
+-   MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Stackdriver logger
 
 A logger for Google's Stackdriver.\
-By default, in debug mode, we fall back back to [`pretty_env_logger`](https://github.com/seanmonstar/pretty-env-logger). \
+By default, in debug mode, we fall back to [`pretty_env_logger`](https://github.com/seanmonstar/pretty-env-logger). \
 In release mode, we output JSON formatted logs compatible with Stackdriver.
 
 ## Usage
 
 ```rust
-use stackdriver_logger;
 use log::{error, info, trace, debug, warn};
 
 fn main() {
@@ -38,7 +37,7 @@ This library accepts a `RUST_LOG` env variable, it works exactly like in [`env_l
 By default, everything is disabled except for `error!`.
 To enable all logs for your application :
 
-```
+```sh
 RUST_LOG=your_application cargo run
 ```
 
@@ -50,7 +49,7 @@ By default, this crate enables all `env_logger` defaults features and always pul
 These crates have some heavy dependencies like `regex`. \
 If you want smaller builds in production, and don't use fancy `env_logger` features, you can disable default features for `stackdriver_logger` like so :
 
-```
+```toml
 stackdriver_logger = { version = "*", default-features = false, features = ["prod"] }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// #![doc(include = "../README.md")]
+#![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
 
 use std::{env, fmt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,14 +148,14 @@ pub(crate) fn try_init(
 // Format log level for Stackdriver
 impl fmt::Display for LogLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            LogLevel(l) if l == &Level::Error => write!(f, "ERROR"),
-            LogLevel(l) if l == &Level::Warn => write!(f, "WARNING"),
-            LogLevel(l) if l == &Level::Info => write!(f, "INFO"),
+        f.write_str(match self {
+            LogLevel(Level::Error) => "ERROR",
+            LogLevel(Level::Warn) => "WARNING",
+            LogLevel(Level::Info) => "INFO",
 
             // Debug and Trace are caught here. Stackdriver doesn't have Trace, we map it to Debug instead
-            LogLevel(_) => write!(f, "DEBUG"),
-        }
+            LogLevel(_) => "DEBUG",
+        })
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,19 +10,15 @@ use toml::Value;
 /// ```rust
 /// use log::info;
 ///
-/// fn main() {
-///     stackdriver_logger::init_with_cargo!();
-///     info!("Default path used for Cargo.toml : ../Cargo.toml");
-/// }
+/// stackdriver_logger::init_with_cargo!();
+/// info!("Default path used for Cargo.toml : ../Cargo.toml");
 /// ```
 /// You can also specify the path if you need to :
 /// ```rust
 /// use log::info;
 ///
-/// fn main() {
-///     stackdriver_logger::init_with_cargo!("../Cargo.toml");
-///     info!("Path was specified !");
-/// }
+/// stackdriver_logger::init_with_cargo!("../Cargo.toml");
+/// info!("Path was specified !");
 /// ```
 /// Note that the `init_with_cargo!` macro will include your `Cargo.toml` in the resulting binary.
 /// If you don't want that, take a look at the other initializers.

--- a/test_snapshots/custom_fields.json
+++ b/test_snapshots/custom_fields.json
@@ -1,12 +1,12 @@
 {
-    "eventTime": "2019-09-28T04:00:00.000000000+00:00",
-    "message": "Info!",
-    "reportLocation": null,
-    "serviceContext": {
-        "service": "test",
-        "version": "0.0.0"
-    },
-    "severity": "INFO",
-    "a": "a value",
-    "b": "b value"
+	"eventTime": "2019-09-28T04:00:00.000000000+00:00",
+	"message": "Info!",
+	"reportLocation": null,
+	"serviceContext": {
+		"service": "test",
+		"version": "0.0.0"
+	},
+	"severity": "INFO",
+	"a": "a value",
+	"b": "b value"
 }

--- a/test_snapshots/info_svc.json
+++ b/test_snapshots/info_svc.json
@@ -1,10 +1,10 @@
 {
-    "eventTime": "2019-09-28T04:00:00.000000000+00:00",
-    "message": "Info!",
-    "reportLocation": null,
-    "serviceContext": {
-        "service": "test",
-        "version": "0.0.0"
-    },
-    "severity": "INFO"
+	"eventTime": "2019-09-28T04:00:00.000000000+00:00",
+	"message": "Info!",
+	"reportLocation": null,
+	"serviceContext": {
+		"service": "test",
+		"version": "0.0.0"
+	},
+	"severity": "INFO"
 }

--- a/test_snapshots/no_scv_no_loc.json
+++ b/test_snapshots/no_scv_no_loc.json
@@ -1,9 +1,9 @@
 {
-    "eventTime": "2019-09-28T04:00:00.000000000+00:00",
-    "message": "Error! \n at my_file.rs:1337",
-    "reportLocation": null,
-    "serviceContext": {
-        "service": "unknown_service"
-    },
-    "severity": "ERROR"
+	"eventTime": "2019-09-28T04:00:00.000000000+00:00",
+	"message": "Error! \n at my_file.rs:1337",
+	"reportLocation": null,
+	"serviceContext": {
+		"service": "unknown_service"
+	},
+	"severity": "ERROR"
 }

--- a/test_snapshots/svc_and_loc.json
+++ b/test_snapshots/svc_and_loc.json
@@ -1,14 +1,14 @@
 {
-    "eventTime": "2019-09-28T04:00:00.000000000+00:00",
-    "message": "Error! \n at my_file.rs:1337",
-    "reportLocation": {
-        "filePath": "my_file.rs",
-        "lineNumber": 1337,
-        "modulePath": "my_module"
-    },
-    "serviceContext": {
-        "service": "test",
-        "version": "0.0.0"
-    },
-    "severity": "ERROR"
+	"eventTime": "2019-09-28T04:00:00.000000000+00:00",
+	"message": "Error! \n at my_file.rs:1337",
+	"reportLocation": {
+		"filePath": "my_file.rs",
+		"lineNumber": 1337,
+		"modulePath": "my_module"
+	},
+	"serviceContext": {
+		"service": "test",
+		"version": "0.0.0"
+	},
+	"severity": "ERROR"
 }


### PR DESCRIPTION
A collection of minor changes. Feel free to cherry-pick fixes, reject what you don't like, whatever.

Formatting: I ran Prettier on the JSON and Markdown files, and EvenBetterTOML on Cargo.toml. Nothing here should be too controversial.

Updating to Rust 2021 doesn't break anything, so it's best to do so. Only one dependency had a breaking release (`env_logger`), and reviewing changelogs indicates that it shouldn't break anything here either. Cargo.toml version has been bumped to reflect the actual version of the crate.

Changes to documentation: put the readme into the generated documentation on docs.rs (there was a commented out attempt to do so, so perhaps it was an intentional decision? The docs.rs page looks very sparse without it, though). In general, I made as few changes as possible to appease `clippy` and make doctests run.

I guess the most controversial change here is reducing redundancy in the `Display` implementation for log levels. The change will probably increase speed and reduce binary size by a non-zero, though likely negligible, amount. It's just simpler, IMO.

Thanks for writing this crate! I know I and the hundreds of other people who download this crate each day really appreciate your work ❤️