### PR TITLE
Drop dependency on old time library through chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ customfields = ["log/kv_unstable"]
 [dependencies]
 env_logger = { version = "0.9.3", default-features = false }
 pretty_env_logger = { version = "0.4.0", optional = true }
-chrono = "0.4.23"
+chrono = { version = "0.4.23", default-features = false, features = "clock" }
 serde_json = "1.0.87"
 log = "0.4.17"
 toml = { version = "0.5.9", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ customfields = ["log/kv_unstable"]
 [dependencies]
 env_logger = { version = "0.9.3", default-features = false }
 pretty_env_logger = { version = "0.4.0", optional = true }
-chrono = { version = "0.4.23", default-features = false, features = "clock" }
+chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
 serde_json = "1.0.87"
 log = "0.4.17"
 toml = { version = "0.5.9", optional = true }


### PR DESCRIPTION
Chrono depends on an old version of the "time" library through a feature "old-time", which is enabled by default. This library has a bug which can cause segfault, so it would be nice to remove it from dependency chains.

See:
https://github.com/time-rs/time/issues/293